### PR TITLE
Add fast scroller to Transfers

### DIFF
--- a/Seeker/Resources/drawable/transfer_fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/transfer_fastscroll_thumb.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="48dp" android:height="48dp"/>
+    <solid android:color="@color/transfers_scrollbar_thumb"/>
+</shape>

--- a/Seeker/Resources/drawable/transfer_fastscroll_track.xml
+++ b/Seeker/Resources/drawable/transfer_fastscroll_track.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size android:width="2dp" />
+    <solid android:color="@color/transfers_scrollbar_track"/>
+</shape>

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -1,6 +1,7 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,6 +13,12 @@
         android:minHeight="25px"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:scrollbars="vertical"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:fastScrollEnabled="true"
+        app:fastScrollVerticalThumbDrawable="@drawable/transfer_fastscroll_thumb"
+        app:fastScrollVerticalTrackDrawable="@drawable/transfer_fastscroll_track"
         android:id="@+id/recyclerView1" />
           <TextView
       android:layout_width = "200dp"

--- a/Seeker/Resources/values/colors.xml
+++ b/Seeker/Resources/values/colors.xml
@@ -49,6 +49,10 @@
 	
   <color name="chipSeparatorColor">#ff606060</color>
 
+  <!-- Colors for transfers fast scroller -->
+  <color name="transfers_scrollbar_thumb">#B3000000</color>
+  <color name="transfers_scrollbar_track">#33000000</color>
+
 
   <color name="absoluteBackColor1">#ff000000</color>
   <color name="absoluteBackColor2">#ff303030</color>

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -681,6 +681,7 @@ namespace Seeker
             }
             //this.primaryListView = rootView.FindViewById<ListView>(Resource.Id.listView1);
             recyclerViewTransferItems = rootView.FindViewById<RecyclerView>(Resource.Id.recyclerView1);
+            ConfigureScrollBar();
             this.noTransfers = rootView.FindViewById<TextView>(Resource.Id.noTransfersView);
             this.setupUpSharing = rootView.FindViewById<Button>(Resource.Id.setUpSharing);
             this.setupUpSharing.Click += SetupUpSharing_Click;
@@ -948,6 +949,7 @@ namespace Seeker
         public override void OnResume()
         {
             StaticHacks.TransfersFrag = this;
+            ConfigureScrollBar();
             if (MainActivity.fromNotificationMoveToUploads)
             {
                 MainActivity.fromNotificationMoveToUploads = false;
@@ -972,6 +974,18 @@ namespace Seeker
             MainActivity.LogDebug("TransferFragment OnPause");  //this occurs when we move to the Account Tab or if we press the home button (i.e. to later kill the process)
                                                                 //so this is a good place to do it.
             SaveTransferItems(sharedPreferences);
+        }
+
+        private void ConfigureScrollBar()
+        {
+            if (recyclerViewTransferItems == null)
+            {
+                return;
+            }
+            var orient = Resources.Configuration.Orientation;
+            recyclerViewTransferItems.ScrollbarFadingEnabled = orient != Orientation.Landscape;
+            recyclerViewTransferItems.ScrollBarFadeDuration = 1000;
+            recyclerViewTransferItems.ScrollBarDefaultDelayBeforeFade = 1000;
         }
 
         public static object TransferStateSaveLock = new object();


### PR DESCRIPTION
## Summary
- enable fast scroll in the Transfers list
- customize the thumb and track colors
- keep scrollbar visible in landscape, fade after 1s otherwise

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ac2510530832d95b41ec6eee87124