### PR TITLE
Fix ambiguous Orientation reference

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -983,7 +983,7 @@ namespace Seeker
                 return;
             }
             var orient = Resources.Configuration.Orientation;
-            recyclerViewTransferItems.ScrollbarFadingEnabled = orient != Orientation.Landscape;
+            recyclerViewTransferItems.ScrollbarFadingEnabled = orient != Android.Content.Res.Orientation.Landscape;
             recyclerViewTransferItems.ScrollBarFadeDuration = 1000;
             recyclerViewTransferItems.ScrollBarDefaultDelayBeforeFade = 1000;
         }


### PR DESCRIPTION
## Summary
- fix compile error by fully-qualifying Orientation enum in `TransfersFragment`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685accc26904832dab5593f5b4e564cc