### PR TITLE
Implement fast scroll on Transfers page

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size android:width="48dp" android:height="48dp" />
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+    <item android:gravity="center">
+        <shape android:shape="rectangle">
+            <size android:width="6dp" android:height="32dp" />
+            <solid android:color="@color/fastscroll_thumb_color" />
+            <corners android:radius="3dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/Seeker/Resources/drawable/fastscroll_track.xml
+++ b/Seeker/Resources/drawable/fastscroll_track.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <size android:width="2dp" android:height="48dp" />
+    <solid android:color="@color/fastscroll_track_color" />
+</shape>

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -1,17 +1,22 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="android.PageFragment"
     android:id="@+id/relativeLayout1">
     <androidx.recyclerview.widget.RecyclerView
-        android:layout_below = "@id/header1"
+        android:layout_below="@id/header1"
+        android:scrollbars="vertical"
+        app:fastScrollEnabled="true"
+        app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
+        app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
         android:minWidth="25px"
         android:minHeight="25px"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:id="@+id/recyclerView1" />
           <TextView
       android:layout_width = "200dp"

--- a/Seeker/Resources/values/colors.xml
+++ b/Seeker/Resources/values/colors.xml
@@ -54,6 +54,10 @@
   <color name="absoluteBackColor2">#ff303030</color>
   <color name="absoluteBackColor3">#ffffff</color>
 
+  <!-- Fast scroller colors -->
+  <color name="fastscroll_thumb_color">#99000000</color>
+  <color name="fastscroll_track_color">#33000000</color>
+
   
   
   

--- a/Seeker/Seeker.csproj
+++ b/Seeker/Seeker.csproj
@@ -92,6 +92,9 @@
     <PackageReference Include="Xamarin.AndroidX.RecyclerView">
       <Version>1.3.0.2</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Paging.Runtime">
+      <Version>3.2.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout">
       <Version>1.2.0.6</Version>
     </PackageReference>

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -685,6 +685,10 @@ namespace Seeker
             this.setupUpSharing = rootView.FindViewById<Button>(Resource.Id.setUpSharing);
             this.setupUpSharing.Click += SetupUpSharing_Click;
 
+            recyclerViewTransferItems.FocusableInTouchMode = true;
+            recyclerViewTransferItems.RequestFocus();
+            recyclerViewTransferItems.KeyPress += RecyclerViewTransferItems_KeyPress;
+
             //View transferOptions = rootView.FindViewById<View>(Resource.Id.transferOptions);
             //transferOptions.Click += TransferOptions_Click;
             this.RegisterForContextMenu(recyclerViewTransferItems); //doesnt work for recycle views
@@ -711,6 +715,8 @@ namespace Seeker
             //            .getSerializable(KEY_LAYOUT_MANAGER);
             //}
 
+            recycleLayoutManager.ItemPrefetchEnabled = true;
+            recyclerViewTransferItems.SetItemViewCacheSize(20);
             recyclerViewTransferItems.SetLayoutManager(recycleLayoutManager);
 
             //// If a layout manager has already been set, get current scroll position.
@@ -954,7 +960,71 @@ namespace Seeker
                 this.MoveToUploadForNotif();
             }
             SetNoTransfersMessage(); // in case coming back from settings
+
+            SetScrollbarVisibility(Resources.Configuration.Orientation);
             base.OnResume();
+        }
+
+        public override void OnConfigurationChanged(Configuration newConfig)
+        {
+            base.OnConfigurationChanged(newConfig);
+            SetScrollbarVisibility(newConfig.Orientation);
+        }
+
+        private void SetScrollbarVisibility(Orientation orientation)
+        {
+            if (recyclerViewTransferItems == null)
+            {
+                return;
+            }
+            if (orientation == Orientation.Landscape)
+            {
+                recyclerViewTransferItems.ScrollbarFadingEnabled = false;
+            }
+            else
+            {
+                recyclerViewTransferItems.ScrollbarFadingEnabled = true;
+                recyclerViewTransferItems.ScrollbarDefaultDelayBeforeFade = 1000;
+            }
+        }
+
+        private void RecyclerViewTransferItems_KeyPress(object sender, View.KeyEventArgs e)
+        {
+            if (e.Event.Action != KeyEventActions.Down)
+            {
+                return;
+            }
+
+            var layoutManager = recyclerViewTransferItems.GetLayoutManager() as LinearLayoutManager;
+            if (layoutManager == null)
+            {
+                return;
+            }
+            int itemCount = recyclerViewTransferItems.GetAdapter()?.ItemCount ?? 0;
+
+            switch (e.KeyCode)
+            {
+                case Keycode.DpadDown:
+                    recyclerViewTransferItems.ScrollBy(0, 100);
+                    break;
+                case Keycode.DpadUp:
+                    recyclerViewTransferItems.ScrollBy(0, -100);
+                    break;
+                case Keycode.PageDown:
+                    recyclerViewTransferItems.ScrollBy(0, recyclerViewTransferItems.Height);
+                    break;
+                case Keycode.PageUp:
+                    recyclerViewTransferItems.ScrollBy(0, -recyclerViewTransferItems.Height);
+                    break;
+                case Keycode.MoveEnd:
+                case Keycode.End:
+                    recyclerViewTransferItems.ScrollToPosition(itemCount - 1);
+                    break;
+                case Keycode.MoveHome:
+                case Keycode.Home:
+                    recyclerViewTransferItems.ScrollToPosition(0);
+                    break;
+            }
         }
 
         public void MoveToUploadForNotif()


### PR DESCRIPTION
## Summary
- enable RecyclerView fast scroller for Transfers screen
- add custom thumb and track drawables
- keep scrollbar visible in landscape and fade in portrait
- support keyboard navigation of the list
- add paging runtime dependency

## Testing
- `dotnet test Seeker/Seeker.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad1de8cb8832db763211e0d8c146a