### PR TITLE
Fix ambiguous Orientation reference

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -971,13 +971,13 @@ namespace Seeker
             SetScrollbarVisibility(newConfig.Orientation);
         }
 
-        private void SetScrollbarVisibility(Orientation orientation)
+        private void SetScrollbarVisibility(Android.Content.Res.Orientation orientation)
         {
             if (recyclerViewTransferItems == null)
             {
                 return;
             }
-            if (orientation == Orientation.Landscape)
+            if (orientation == Android.Content.Res.Orientation.Landscape)
             {
                 recyclerViewTransferItems.ScrollbarFadingEnabled = false;
             }


### PR DESCRIPTION
## Summary
- fix ambiguous `Orientation` reference in `TransfersFragment`

## Testing
- `dotnet build Seeker/Seeker.csproj -c Release` *(fails: `dotnet: command not found`)*
- `dotnet test UnitTestCommon/UnitTestCommon.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aecea0cec832db8f68e8c98d64a9a