### PR TITLE
Fix Android property and Keycode for TransfersFragment

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -984,7 +984,7 @@ namespace Seeker
             else
             {
                 recyclerViewTransferItems.ScrollbarFadingEnabled = true;
-                recyclerViewTransferItems.ScrollbarDefaultDelayBeforeFade = 1000;
+                recyclerViewTransferItems.ScrollBarDefaultDelayBeforeFade = 1000;
             }
         }
 
@@ -1017,7 +1017,6 @@ namespace Seeker
                     recyclerViewTransferItems.ScrollBy(0, -recyclerViewTransferItems.Height);
                     break;
                 case Keycode.MoveEnd:
-                case Keycode.End:
                     recyclerViewTransferItems.ScrollToPosition(itemCount - 1);
                     break;
                 case Keycode.MoveHome:


### PR DESCRIPTION
## Summary
- correct spelling for `ScrollBarDefaultDelayBeforeFade`
- remove invalid `Keycode.End` case

## Testing
- `dotnet build Seeker/Seeker.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aee0b2e50832da8e5f2f67d02b98f