### PR TITLE
Fix Transfers page crash after adding scroll bar

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -984,7 +984,10 @@ namespace Seeker
             else
             {
                 recyclerViewTransferItems.ScrollbarFadingEnabled = true;
-                recyclerViewTransferItems.ScrollBarDefaultDelayBeforeFade = 1000;
+                if ((int)Build.VERSION.SdkInt >= 26)
+                {
+                    recyclerViewTransferItems.ScrollBarDefaultDelayBeforeFade = 1000;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- guard scroll bar fade configuration behind API level check

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af20211ec832d85513007d25261c8