### PR TITLE
Fix fast scroller drawable causing crash

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape android:shape="rectangle">
-            <size android:width="48dp" android:height="48dp" />
-            <solid android:color="@android:color/transparent" />
-        </shape>
-    </item>
-    <item android:gravity="center">
         <shape android:shape="rectangle">
             <size android:width="6dp" android:height="32dp" />
             <solid android:color="@color/fastscroll_thumb_color" />
             <corners android:radius="3dp" />
         </shape>
     </item>
-</layer-list>
+</selector>


### PR DESCRIPTION
## Summary
- replace `fastscroll_thumb.xml` LayerDrawable with StateListDrawable selector

## Testing
- `dotnet test --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afa81ed08832dac978311ff5fb861