### PR TITLE
Add vertical scrollbar to Transfers layout

### DIFF
--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -10,6 +10,7 @@
         android:layout_below = "@id/header1"
         android:minWidth="25px"
         android:minHeight="25px"
+        android:scrollbars="vertical"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/recyclerView1" />


### PR DESCRIPTION
## Summary
- enable vertical scroll indicator in Transfers list just like the Search page

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b02476888832d9e2e7dd794b83df7