### PR TITLE
Add clickable scrollbar with larger thumb

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size android:width="48dp" android:height="48dp" />
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+    <item android:gravity="center">
+        <shape android:shape="rectangle">
+            <size android:width="6dp" android:height="32dp" />
+            <solid android:color="@color/fastscroll_thumb_color" />
+            <corners android:radius="3dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/Seeker/Resources/drawable/fastscroll_track.xml
+++ b/Seeker/Resources/drawable/fastscroll_track.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <size android:width="2dp" android:height="48dp" />
+    <solid android:color="@color/fastscroll_track_color" />
+</shape>

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -1,18 +1,22 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="android.PageFragment"
     android:id="@+id/relativeLayout1">
     <androidx.recyclerview.widget.RecyclerView
-        android:layout_below = "@id/header1"
+        android:layout_below="@id/header1"
+        android:scrollbars="vertical"
+        app:fastScrollEnabled="true"
+        app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
+        app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
         android:minWidth="25px"
         android:minHeight="25px"
-        android:scrollbars="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:id="@+id/recyclerView1" />
           <TextView
       android:layout_width = "200dp"

--- a/Seeker/Resources/values/colors.xml
+++ b/Seeker/Resources/values/colors.xml
@@ -54,6 +54,10 @@
   <color name="absoluteBackColor2">#ff303030</color>
   <color name="absoluteBackColor3">#ffffff</color>
 
+  <!-- Fast scroller colors -->
+  <color name="fastscroll_thumb_color">#99000000</color>
+  <color name="fastscroll_track_color">#33000000</color>
+
   
   
   


### PR DESCRIPTION
## Summary
- implement fast scroll support for the Transfers list
- provide custom fast scroll thumb and track drawables with a 48dp touch target
- define colors for fast scroll elements

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b07f815d4832dbd39852decd80079