### PR TITLE
Fix fast scroll crash

### DIFF
--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -15,6 +15,8 @@
         app:fastScrollEnabled="true"
         app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
         app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
+        app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
+        app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:id="@+id/recyclerView1" />


### PR DESCRIPTION
## Summary
- update transfers layout to include horizontal fast-scroll drawables

## Testing
- `dotnet test Seeker.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b1a09be98832dac2f7cb5cddf1f4f