### PR TITLE
Fix double scrollbar on Search page

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -34,7 +34,6 @@
         <androidx.recyclerview.widget.RecyclerView
             android:layout_below = "@id/recyclerViewChips"
             android:minWidth="25px"
-            android:scrollbars="vertical"
             app:fastScrollEnabled="true"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"


### PR DESCRIPTION
## Summary
- remove the default vertical scrollbar from Search results

## Testing
- `dotnet test UnitTestCommon/UnitTestCommon.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3489b93c832d8f76c45f0856a931