### PR TITLE
Fix fast scroll activation

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -32,14 +32,20 @@
         android:id="@+id/recyclerViewChips" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:layout_below = "@id/recyclerViewChips"
+            android:layout_below="@id/recyclerViewChips"
             android:minWidth="25px"
+            android:scrollbars="vertical"
+            android:fastScrollEnabled="true"
             app:fastScrollEnabled="true"
+            android:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
+            android:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
+            android:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
+            android:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
             app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
-                  android:paddingBottom="80dp"
+            android:paddingBottom="80dp"
             android:clipToPadding="false"
             android:minHeight="25px"
             android:layout_width="wrap_content"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -8,11 +8,16 @@
     tools:context="android.PageFragment"
     android:id="@+id/relativeLayout1">
     <androidx.recyclerview.widget.RecyclerView
-        android:layout_below = "@id/header1"
+        android:layout_below="@id/header1"
         android:minWidth="25px"
         android:minHeight="25px"
         android:scrollbars="vertical"
+        android:fastScrollEnabled="true"
         app:fastScrollEnabled="true"
+        android:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
+        android:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
+        android:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
+        android:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
         app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
         app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
         app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"


### PR DESCRIPTION
## Summary
- enable RecyclerView fast scroll on Transfers and Search pages

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c370d43e0832dabc99119f09a50bd