### PR TITLE
Fix fast scroll overlays

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     >
   <LinearLayout
     android:id="@+id/focusableLayout"
@@ -33,9 +33,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:layout_below="@id/recyclerViewChips"
-            android:minWidth="25px"
-            android:scrollbars="vertical"
-            app:fastScrollEnabled="true"
+        android:minWidth="25px"
+        app:fastScrollEnabled="true"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
             app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
@@ -43,8 +42,8 @@
             android:paddingBottom="80dp"
             android:clipToPadding="false"
             android:minHeight="25px"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:id="@+id/recyclerViewSearches" />
 
     </RelativeLayout>

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -3,15 +3,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
     tools:context="android.PageFragment"
     android:id="@+id/relativeLayout1">
     <androidx.recyclerview.widget.RecyclerView
         android:layout_below="@id/header1"
         android:minWidth="25px"
         android:minHeight="25px"
-        android:scrollbars="vertical"
         app:fastScrollEnabled="true"
         app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
         app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
@@ -31,9 +30,9 @@
       android:layout_centerVertical="true"
       android:textColor = "?attr/mainTextColorHinted"
       android:textSize = "20dp" />
-	<Button
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
+<Button
+android:layout_width="match_parent"
+android:layout_height="wrap_content"
 	android:text="@string/setUpSharing"
 	android:id="@+id/setUpSharing"
 	android:textSize="16dp"


### PR DESCRIPTION
## Summary
- adjust Search and Transfers layouts for fast scroll thumb to work
- avoid large overlay in Transfers page

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c40d4b53c832d81f8cd55f3de520f