### PR TITLE
Increase fast scroll handle size

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb.xml
@@ -2,9 +2,10 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <size android:width="6dp" android:height="32dp" />
+            <!-- Wider and taller thumb for easier touch interaction -->
+            <size android:width="24dp" android:height="48dp" />
             <solid android:color="@color/fastscroll_thumb_color" />
-            <corners android:radius="3dp" />
+            <corners android:radius="12dp" />
         </shape>
     </item>
 </selector>

--- a/Seeker/Resources/drawable/fastscroll_track.xml
+++ b/Seeker/Resources/drawable/fastscroll_track.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <size android:width="2dp" android:height="48dp" />
+    <!-- Match the thumb width and ensure sufficient height -->
+    <size android:width="24dp" android:height="48dp" />
     <solid android:color="@color/fastscroll_track_color" />
 </shape>


### PR DESCRIPTION
## Summary
- widen and lengthen the fast scroll thumb for easier touch
- match the track size to the thumb

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c66e95f24832d903833ab9fa722f9