### PR TITLE
Fix fast scroll sizing

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb.xml
@@ -2,9 +2,8 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <!-- Wider and taller thumb for easier touch interaction -->
             <!-- Ensure recommended minimum touch size -->
-            <size android:width="48dp" android:height="48dp" />
+            <size android:width="24dp" android:height="48dp" />
             <solid android:color="@color/fastscroll_thumb_color" />
             <corners android:radius="12dp" />
         </shape>

--- a/Seeker/Resources/drawable/fastscroll_track.xml
+++ b/Seeker/Resources/drawable/fastscroll_track.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <!-- Match the thumb width and ensure sufficient height -->
-    <size android:width="48dp" android:height="48dp" />
+    <!-- Match the thumb width; let the height stretch to fill -->
+    <size android:width="24dp" />
     <solid android:color="@color/fastscroll_track_color" />
 </shape>

--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -39,6 +39,7 @@
                 app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
                 app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
                 app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
+                app:fastScrollMinimumRange="@dimen/fastscroll_minimum_range"
                 android:paddingBottom="80dp"
                 android:clipToPadding="false"
                 android:minHeight="25px"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -16,6 +16,7 @@
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
             app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
+            app:fastScrollMinimumRange="@dimen/fastscroll_minimum_range"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/recyclerView1"/>


### PR DESCRIPTION
## Summary
- adjust fast-scroll thumb/track size to 24dp wide
- enforce minimum thumb height by using `app:fastScrollMinimumRange`

## Testing
- `dotnet test --no-restore --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7487a7cc832d8a501148a68a5699