### PR TITLE
Remove unsupported attribute from RecyclerView layouts

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -39,7 +39,6 @@
                 app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
                 app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
                 app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
-                app:fastScrollMinimumRange="@dimen/fastscroll_minimum_range"
                 android:paddingBottom="80dp"
                 android:clipToPadding="false"
                 android:minHeight="25px"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -16,7 +16,6 @@
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
             app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
-            app:fastScrollMinimumRange="@dimen/fastscroll_minimum_range"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/recyclerView1"/>


### PR DESCRIPTION
## Summary
- fix build failure by removing the unsupported `fastScrollMinimumRange` attribute from `searches.xml` and `transfers.xml`

## Testing
- `dotnet build Seeker.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c787e1f78832dbd03b62640c46900