### PR TITLE
Add MaterialScrollBar to Search and Transfers pages

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -46,6 +46,14 @@
                 android:layout_height="match_parent"
                 android:id="@+id/recyclerViewSearches"/>
 
+        <com.turingtechnologies.materialscrollbar.MaterialScrollBar
+                android:id="@+id/scrollBarSearch"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentEnd="true"
+                android:layout_alignTop="@id/recyclerViewSearches"
+                android:layout_alignBottom="@id/recyclerViewSearches" />
+
     </RelativeLayout>
     <RelativeLayout
             android:layout_width="match_parent"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -19,6 +19,14 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/recyclerView1"/>
+
+    <com.turingtechnologies.materialscrollbar.MaterialScrollBar
+            android:id="@+id/scrollBarTransfers"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_alignParentEnd="true"
+            android:layout_alignTop="@id/recyclerView1"
+            android:layout_alignBottom="@id/recyclerView1" />
     <TextView
             android:layout_width="200dp"
             android:layout_height="match_parent"

--- a/Seeker/Search/SearchFragment.cs
+++ b/Seeker/Search/SearchFragment.cs
@@ -11,6 +11,7 @@ using Android.Widget;
 using AndroidX.Core.Content;
 using AndroidX.Fragment.App;
 using AndroidX.RecyclerView.Widget;
+using Com.Turingtechnologies.Materialscrollbar;
 using Google.Android.Material.BottomNavigation;
 using Google.Android.Material.BottomSheet;
 using Google.Android.Material.FloatingActionButton;
@@ -912,6 +913,12 @@ namespace Seeker
             recycleLayoutManager = new LinearLayoutManager(Activity);
             recyclerViewTransferItems.SetItemAnimator(null); //todo
             recyclerViewTransferItems.SetLayoutManager(recycleLayoutManager);
+
+            var scrollBar = rootView.FindViewById<MaterialScrollBar>(Resource.Id.scrollBarSearch);
+            if (scrollBar != null)
+            {
+                scrollBar.SetRecyclerView(recyclerViewTransferItems);
+            }
             if (SearchTabHelper.FilteredResults)
             {
                 recyclerSearchAdapter = new SearchAdapterRecyclerVersion(SearchTabHelper.UI_SearchResponses);

--- a/Seeker/Seeker.csproj
+++ b/Seeker/Seeker.csproj
@@ -97,6 +97,7 @@
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials" Version="1.7.6" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1.2" />
+    <PackageReference Include="MaterialScrollBarXamarin" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -7,6 +7,7 @@ using Android.Views;
 using Android.Widget;
 using AndroidX.Fragment.App;
 using AndroidX.RecyclerView.Widget;
+using Com.Turingtechnologies.Materialscrollbar;
 using Google.Android.Material.BottomNavigation;
 using Seeker.Transfers;
 using Soulseek;
@@ -712,6 +713,12 @@ namespace Seeker
             //}
 
             recyclerViewTransferItems.SetLayoutManager(recycleLayoutManager);
+
+            var scrollBar = rootView.FindViewById<MaterialScrollBar>(Resource.Id.scrollBarTransfers);
+            if (scrollBar != null)
+            {
+                scrollBar.SetRecyclerView(recyclerViewTransferItems);
+            }
 
             //// If a layout manager has already been set, get current scroll position.
             //if (mRecyclerView.getLayoutManager() != null)


### PR DESCRIPTION
## Summary
- add MaterialScrollBar views in search and transfers layouts
- hook MaterialScrollBar to RecyclerViews in SearchFragment and TransfersFragment
- include MaterialScrollBarXamarin package

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7ca7c274832d946ff8e58c5b7f9a