### PR TITLE
Fix FastScroll package reference

### DIFF
--- a/Seeker/Seeker.csproj
+++ b/Seeker/Seeker.csproj
@@ -93,7 +93,7 @@
       <Version>1.3.0.2</Version>
     </PackageReference>
     <PackageReference Include="Karamunting.Android.Timusus.RecyclerViewFastScroll">
-      <Version>2.0.1</Version>
+      <Version>1.0.9</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout">
       <Version>1.2.0.6</Version>


### PR DESCRIPTION
## Summary
- update fast scroller dependency version to available 1.0.9

## Testing
- `dotnet restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686008fc2080832daf560501c4d7ec04