### PR TITLE
Add accessible scrollbars and transfer filtering

### DIFF
--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -31,10 +31,10 @@
 
         android:id="@+id/recyclerViewChips" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <Seeker.AccessibleRecyclerView
             android:layout_below = "@id/recyclerViewChips"
             android:minWidth="25px"
-            android:scrollbars="vertical"
+            android:scrollbars="none"
                   android:paddingBottom="80dp"
             android:clipToPadding="false"
             android:minHeight="25px"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -1,4 +1,3 @@
-
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -7,48 +6,90 @@
     android:layout_height="match_parent"
     tools:context="android.PageFragment"
     android:id="@+id/relativeLayout1">
-    <androidx.recyclerview.widget.RecyclerView
-        android:layout_below = "@id/header1"
-        android:minWidth="25px"
-        android:minHeight="25px"
-        android:layout_width="wrap_content"
+
+    <LinearLayout
+        android:id="@+id/transferFilterPanel"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scrollbars="vertical"
+        android:layout_alignParentTop="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp">
+
+        <EditText
+            android:id="@+id/transferFilterText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/filter_transfers"
+            android:imeOptions="actionDone"
+            android:maxLines="1"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:singleLine="true"
+            android:textColor="?attr/mainTextColor"
+            android:textColorHint="?attr/mainTextColorHinted" />
+
+        <ImageButton
+            android:id="@+id/transferFilterClear"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginStart="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/clear_filter"
+            android:padding="6dp"
+            android:src="@drawable/ic_clear_black_24"
+            android:tint="?attr/mainTextColor"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <Seeker.AccessibleRecyclerView
+        android:id="@+id/recyclerView1"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/transferFilterPanel"
+        android:clipToPadding="false"
         android:focusable="true"
         android:focusableInTouchMode="true"
+        android:paddingBottom="8dp"
+        android:scrollbars="none"
         app:fastScrollEnabled="true"
         app:fastScrollVerticalThumbDrawable="@drawable/transfer_fastscroll_thumb"
-        app:fastScrollVerticalTrackDrawable="@drawable/transfer_fastscroll_track"
-        android:id="@+id/recyclerView1" />
-          <TextView
-      android:layout_width = "200dp"
-      android:layout_height = "wrap_content"
-      android:text = "@string/no_transfers_yet"
-      android:id = "@+id/noTransfersView"
-        android:textAlignment="center"
-      android:layout_centerHorizontal = "true"
-        android:paddingBottom="150dp"
-      android:layout_centerVertical="true"
-      android:textColor = "?attr/mainTextColorHinted"
-      android:textSize = "20dp" />
-	<Button
-	android:layout_width="wrap_content"
-	android:layout_height="wrap_content"
-	android:text="@string/setUpSharing"
-	android:id="@+id/setUpSharing"
-	android:textSize="16dp"
-        
-	android:paddingTop="8dp"
-	android:paddingBottom="8dp"
-	android:paddingStart="7dp"
-	android:paddingEnd="7dp"
-        
-	android:textAllCaps="false"
-	android:minHeight="16dp"
-	android:foreground="@drawable/button"
-	style="@style/SeekerButtonStyle"
+        app:fastScrollVerticalTrackDrawable="@drawable/transfer_fastscroll_track" />
 
-	android:layout_below="@id/noTransfersView"
-	android:layout_centerHorizontal="true"
-	android:translationY="-140dp"/>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/noTransfersView"
+        android:layout_below="@id/transferFilterPanel"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="48dp"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:text="@string/no_transfers_yet"
+        android:textAlignment="center"
+        android:textColor="?attr/mainTextColorHinted"
+        android:textSize="20sp" />
+
+    <Button
+        android:id="@+id/setUpSharing"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/noTransfersView"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:foreground="@drawable/button"
+        android:minHeight="16dp"
+        android:paddingStart="7dp"
+        android:paddingEnd="7dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:text="@string/setUpSharing"
+        android:textAllCaps="false"
+        android:textSize="16sp"
+        style="@style/SeekerButtonStyle" />
+
 </RelativeLayout>

--- a/Seeker/Resources/values-ru/strings.xml
+++ b/Seeker/Resources/values-ru/strings.xml
@@ -87,6 +87,8 @@
     <string name="chatroom_enter_message">Введите сообщение</string>
     <string name="send_message">Отправить</string>
     <string name="filter_chatrooms_here">Фильтр</string>
+    <string name="filter_transfers">Фильтр передач</string>
+    <string name="clear_filter">Очистить фильтр</string>
     <string name="enter_listening_port">Введите порт для прослушивания</string>
     <string name="create_chatroom_name">Имя комнаты</string>
     <string name="create_chatroom_private">Сделать приватной</string>

--- a/Seeker/Resources/values/strings.xml
+++ b/Seeker/Resources/values/strings.xml
@@ -99,6 +99,8 @@ Directory Count: {5}"</string>
   <string name="chatroom_enter_message">Enter Message</string>
   <string name="send_message">Send</string>
   <string name="filter_chatrooms_here">Filter here</string>
+  <string name="filter_transfers">Filter transfers</string>
+  <string name="clear_filter">Clear filter</string>
 
   <string name="enter_listening_port">Enter Port to Listen On</string>
 

--- a/Seeker/Transfers/TransferItemViews.cs
+++ b/Seeker/Transfers/TransferItemViews.cs
@@ -207,7 +207,18 @@ namespace Seeker
                 }
 #pragma warning restore 0618
             }
-            if (isInBatchMode && TransfersFragment.BatchSelectedItems.Contains(this.ViewHolder.AbsoluteAdapterPosition))
+            bool isSelected = false;
+            int adapterPosition = this.ViewHolder?.AbsoluteAdapterPosition ?? -1;
+            if (adapterPosition >= 0 && StaticHacks.TransfersFrag?.recyclerTransferAdapter != null)
+            {
+                int modelIndex = StaticHacks.TransfersFrag.recyclerTransferAdapter.TranslateAdapterPositionToModelIndex(adapterPosition);
+                if (modelIndex >= 0)
+                {
+                    isSelected = TransfersFragment.BatchSelectedItems.Contains(modelIndex);
+                }
+            }
+
+            if (isInBatchMode && isSelected)
             {
                 if ((int)Android.OS.Build.VERSION.SdkInt >= 21)
                 {
@@ -799,7 +810,18 @@ namespace Seeker
 
             }
 
-            if (isInBatchMode && TransfersFragment.BatchSelectedItems.Contains(this.ViewHolder.AbsoluteAdapterPosition))
+            bool isSelected = false;
+            int adapterPosition = this.ViewHolder?.AbsoluteAdapterPosition ?? -1;
+            if (adapterPosition >= 0 && StaticHacks.TransfersFrag?.recyclerTransferAdapter != null)
+            {
+                int modelIndex = StaticHacks.TransfersFrag.recyclerTransferAdapter.TranslateAdapterPositionToModelIndex(adapterPosition);
+                if (modelIndex >= 0)
+                {
+                    isSelected = TransfersFragment.BatchSelectedItems.Contains(modelIndex);
+                }
+            }
+
+            if (isInBatchMode && isSelected)
             {
                 if ((int)Android.OS.Build.VERSION.SdkInt >= 21)
                 {

--- a/Seeker/Utils/AccessibleRecyclerView.cs
+++ b/Seeker/Utils/AccessibleRecyclerView.cs
@@ -1,0 +1,181 @@
+using System;
+using Android.Content;
+using Android.Util;
+using Android.Views;
+using AndroidX.RecyclerView.Widget;
+
+namespace Seeker
+{
+    /// <summary>
+    /// RecyclerView with improved accessibility support for keyboard, mouse and scrollbar gestures.
+    /// </summary>
+    public class AccessibleRecyclerView : RecyclerView
+    {
+        private readonly int scrollbarTouchInset;
+        private const int DefaultTrackTouchAdditionalInsetDp = 16;
+
+        public AccessibleRecyclerView(Context context) : base(context)
+        {
+            scrollbarTouchInset = ResolveScrollbarTouchInset(context, null);
+            Initialize();
+        }
+
+        public AccessibleRecyclerView(Context context, IAttributeSet attrs) : base(context, attrs)
+        {
+            scrollbarTouchInset = ResolveScrollbarTouchInset(context, attrs);
+            Initialize();
+        }
+
+        public AccessibleRecyclerView(Context context, IAttributeSet attrs, int defStyle) : base(context, attrs, defStyle)
+        {
+            scrollbarTouchInset = ResolveScrollbarTouchInset(context, attrs);
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            Focusable = true;
+            FocusableInTouchMode = true;
+            VerticalScrollBarEnabled = false;
+        }
+
+        private static int ResolveScrollbarTouchInset(Context context, IAttributeSet attrs)
+        {
+            int baseSize = 0;
+            if (context?.Resources != null)
+            {
+                baseSize = context.Resources.GetDimensionPixelSize(Android.Resource.Dimension.ScrollbarSize);
+                int additional = (int)(context.Resources.DisplayMetrics.Density * DefaultTrackTouchAdditionalInsetDp);
+                baseSize += additional;
+            }
+
+            if (baseSize == 0)
+            {
+                baseSize = (int)(ViewConfiguration.Get(context).ScaledTouchSlop * 2);
+            }
+
+            return baseSize;
+        }
+
+        public override bool OnTouchEvent(MotionEvent e)
+        {
+            if (HandleScrollbarTap(e))
+            {
+                return true;
+            }
+
+            return base.OnTouchEvent(e);
+        }
+
+        private bool HandleScrollbarTap(MotionEvent e)
+        {
+            if (e == null)
+            {
+                return false;
+            }
+
+            if (e.Action != MotionEventActions.Down)
+            {
+                return false;
+            }
+
+            if (!CanScrollVertically(-1) && !CanScrollVertically(1))
+            {
+                return false;
+            }
+
+            float x = e.GetX();
+            if (x < Width - scrollbarTouchInset)
+            {
+                return false;
+            }
+
+            int range = ComputeVerticalScrollRange() - ComputeVerticalScrollExtent();
+            if (range <= 0)
+            {
+                return false;
+            }
+
+            float proportion = e.GetY() / Height;
+            proportion = Math.Max(0f, Math.Min(1f, proportion));
+            int targetOffset = (int)(proportion * range);
+            int currentOffset = ComputeVerticalScrollOffset();
+            int dy = targetOffset - currentOffset;
+            if (dy == 0)
+            {
+                return false;
+            }
+
+            ScrollBy(0, dy);
+            return true;
+        }
+
+        public override bool OnKeyDown(Keycode keyCode, KeyEvent e)
+        {
+            if (HandleKeyboardNavigation(keyCode))
+            {
+                return true;
+            }
+
+            return base.OnKeyDown(keyCode, e);
+        }
+
+        private bool HandleKeyboardNavigation(Keycode keyCode)
+        {
+            if (LayoutManager == null)
+            {
+                return false;
+            }
+
+            switch (keyCode)
+            {
+                case Keycode.PageDown:
+                    ScrollByPage(forward: true);
+                    return true;
+                case Keycode.PageUp:
+                    ScrollByPage(forward: false);
+                    return true;
+                case Keycode.MoveEnd:
+                    ScrollToEdge(forward: true);
+                    return true;
+                case Keycode.MoveHome:
+                    ScrollToEdge(forward: false);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private void ScrollByPage(bool forward)
+        {
+            int distance = Height;
+            if (distance <= 0)
+            {
+                distance = 1;
+            }
+
+            int dy = forward ? distance : -distance;
+            SmoothScrollBy(0, dy);
+        }
+
+        private void ScrollToEdge(bool forward)
+        {
+            var adapter = GetAdapter();
+            if (adapter == null || adapter.ItemCount == 0)
+            {
+                return;
+            }
+
+            if (LayoutManager is LinearLayoutManager linearLayoutManager)
+            {
+                int target = forward ? adapter.ItemCount - 1 : 0;
+                linearLayoutManager.ScrollToPositionWithOffset(target, 0);
+            }
+            else
+            {
+                int target = forward ? adapter.ItemCount - 1 : 0;
+                ScrollToPosition(target);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the transfers and searches RecyclerViews with an accessible implementation that adds keyboard navigation and scrollbar tap support
- introduce a real-time filter panel for transfers and wire the adapters to respect filtered data while keeping batch selection intact
- update resources and strings, including Russian localization, to support the new UI elements

## Testing
- `dotnet build Seeker.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0f4ae1868832dafe96323f60948bb