### PR TITLE
Enhance transfers filtering and scrolling

### DIFF
--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -6,11 +6,34 @@
         android:layout_height="match_parent"
         tools:context="android.PageFragment"
         android:id="@+id/relativeLayout1">
-    <androidx.recyclerview.widget.RecyclerView
-            android:layout_below="@id/header1"
-            android:minWidth="25px"
-            android:minHeight="25px"
-            android:scrollbars="vertical"
+    <LinearLayout
+            android:id="@+id/transfersFilterPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="8dp"
+            android:layout_alignParentTop="true">
+
+        <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/transfers_filter_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/transfersFilterInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:singleLine="true"/>
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <Seeker.Views.EnhancedRecyclerView
+            android:layout_below="@id/transfersFilterPanel"
             app:fastScrollEnabled="true"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
@@ -27,7 +50,7 @@
             android:textAlignment="center"
             android:layout_centerHorizontal="true"
             android:paddingBottom="150dp"
-            android:layout_centerVertical="true"
+            android:layout_below="@id/transfersFilterPanel"
             android:textColor="?attr/mainTextColorHinted"
             android:textSize="20dp"/>
     <Button

--- a/Seeker/Resources/values/strings.xml
+++ b/Seeker/Resources/values/strings.xml
@@ -189,6 +189,8 @@ Directory Count: {5}"</string>
   <string name="restore_default_settings">Restore Defaults</string>
 
   <string name="no_transfers_yet">No downloads currently, as you download content it will appear here</string>
+  <string name="transfers_filter_hint">Filter transfers</string>
+  <string name="transfers_filter_no_results">No transfers match the current filter.</string>
 
 
   <string name="user_has_no_bio">User has no bio.</string>

--- a/Seeker/Transfers/TransferItemManager.cs
+++ b/Seeker/Transfers/TransferItemManager.cs
@@ -659,12 +659,17 @@ namespace Seeker
                 }
 
 
+                var globalIndexes = TransfersFragment.BatchSelectedItems
+                    .Select(TransfersFragment.GetGlobalIndexFromAdapterPosition)
+                    .Where(idx => idx != -1)
+                    .ToList();
+
                 if (isFolderItems)
                 {
                     List<FolderItem> toClear = new List<FolderItem>();
-                    foreach (int pos in TransfersFragment.BatchSelectedItems)
+                    foreach (int index in globalIndexes)
                     {
-                        toClear.Add(GetItemAtUserIndex(pos) as FolderItem);
+                        toClear.Add(GetItemAtUserIndex(index) as FolderItem);
                     }
                     foreach (FolderItem item in toClear)
                     {
@@ -676,15 +681,15 @@ namespace Seeker
                 {
                     List<TransferItem> toCleanUp = new List<TransferItem>();
                     List<TransferItem> toClear = new List<TransferItem>();
-                    TransfersFragment.BatchSelectedItems.Sort();
-                    TransfersFragment.BatchSelectedItems.Reverse();
-                    foreach (int pos in TransfersFragment.BatchSelectedItems)
+                    globalIndexes.Sort();
+                    globalIndexes.Reverse();
+                    foreach (int index in globalIndexes)
                     {
-                        if (TransferItemManagerWrapper.NeedsCleanUp(GetItemAtUserIndex(pos) as TransferItem))
+                        if (TransferItemManagerWrapper.NeedsCleanUp(GetItemAtUserIndex(index) as TransferItem))
                         {
-                            toCleanUp.Add(GetItemAtUserIndex(pos) as TransferItem);
+                            toCleanUp.Add(GetItemAtUserIndex(index) as TransferItem);
                         }
-                        this.RemoveAtUserIndex(pos);
+                        this.RemoveAtUserIndex(index);
                     }
                 }
             }
@@ -766,17 +771,22 @@ namespace Seeker
                     isFolderItems = true;
                 }
 
-                for (int i = 0; i < TransfersFragment.BatchSelectedItems.Count; i++)
+                var globalIndexes = TransfersFragment.BatchSelectedItems
+                    .Select(TransfersFragment.GetGlobalIndexFromAdapterPosition)
+                    .Where(idx => idx != -1)
+                    .ToList();
+
+                for (int i = 0; i < globalIndexes.Count; i++)
                 {
                     //CancellationTokens[ProduceCancellationTokenKey(transferItems[i])]?.Cancel();
                     if (isFolderItems)
                     {
-                        FolderItem fi = this.GetItemAtUserIndex(TransfersFragment.BatchSelectedItems[i]) as FolderItem;
+                        FolderItem fi = this.GetItemAtUserIndex(globalIndexes[i]) as FolderItem;
                         CancelFolder(fi, prepareForClear);
                     }
                     else
                     {
-                        TransferItem ti = this.GetItemAtUserIndex(TransfersFragment.BatchSelectedItems[i]) as TransferItem;
+                        TransferItem ti = this.GetItemAtUserIndex(globalIndexes[i]) as TransferItem;
                         if (prepareForClear)
                         {
                             if (ti.InProcessing) //let continuation action clear this guy

--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -5,12 +5,15 @@ using Android.OS;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using Android.Text;
 using AndroidX.Fragment.App;
 using AndroidX.RecyclerView.Widget;
 using Google.Android.Material.BottomNavigation;
+using Google.Android.Material.TextField;
 using Seeker.Transfers;
 using Soulseek;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -88,9 +91,13 @@ namespace Seeker
         //private ListView primaryListView = null;
         private TextView noTransfers = null;
         private Button setupUpSharing = null;
+        private TextInputEditText transfersFilterInput = null;
+        private string currentFilterQuery = string.Empty;
         private ISharedPreferences sharedPreferences = null;
         private static System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> ProgressUpdatedThrottler = new System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>();
         public static int THROTTLE_PROGRESS_UPDATED_RATE = 200;//in ms;
+
+        private bool IsFilterActive => !string.IsNullOrWhiteSpace(currentFilterQuery?.Trim());
 
         public override void SetMenuVisibility(bool menuVisible)
         {
@@ -622,6 +629,21 @@ namespace Seeker
 
         private void SetNoTransfersMessage()
         {
+            if (IsFilterActive)
+            {
+                if (recyclerTransferAdapter != null && recyclerTransferAdapter.ItemCount > 0)
+                {
+                    noTransfers.Visibility = ViewStates.Gone;
+                }
+                else
+                {
+                    noTransfers.Visibility = ViewStates.Visible;
+                    noTransfers.Text = SeekerState.ActiveActivityRef.GetString(Resource.String.transfers_filter_no_results);
+                }
+                setupUpSharing.Visibility = ViewStates.Gone;
+                return;
+            }
+
             if (TransfersFragment.InUploadsMode)
             {
                 if (!(TransferItemManagerUploads.IsEmpty()))
@@ -681,9 +703,22 @@ namespace Seeker
             }
             //this.primaryListView = rootView.FindViewById<ListView>(Resource.Id.listView1);
             recyclerViewTransferItems = rootView.FindViewById<RecyclerView>(Resource.Id.recyclerView1);
+            recyclerViewTransferItems.Focusable = true;
+            recyclerViewTransferItems.FocusableInTouchMode = true;
             this.noTransfers = rootView.FindViewById<TextView>(Resource.Id.noTransfersView);
             this.setupUpSharing = rootView.FindViewById<Button>(Resource.Id.setUpSharing);
             this.setupUpSharing.Click += SetupUpSharing_Click;
+
+            transfersFilterInput = rootView.FindViewById<TextInputEditText>(Resource.Id.transfersFilterInput);
+            if (transfersFilterInput != null)
+            {
+                if (!string.IsNullOrEmpty(currentFilterQuery))
+                {
+                    transfersFilterInput.Text = currentFilterQuery;
+                    transfersFilterInput.SetSelection(transfersFilterInput.Text?.Length ?? 0);
+                }
+                transfersFilterInput.TextChanged += TransfersFilterInput_TextChanged;
+            }
 
             //View transferOptions = rootView.FindViewById<View>(Resource.Id.transferOptions);
             //transferOptions.Click += TransferOptions_Click;
@@ -743,6 +778,23 @@ namespace Seeker
             SeekerState.MainActivityRef.StartActivityForResult(intent2, 140);
         }
 
+        private void TransfersFilterInput_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            string newQuery = e?.Text?.ToString() ?? string.Empty;
+            if (string.Equals(currentFilterQuery, newQuery, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            currentFilterQuery = newQuery;
+            if (TransfersActionMode != null)
+            {
+                TransfersActionMode.Finish();
+            }
+            BatchSelectedItems.Clear();
+            SetRecyclerAdapter();
+        }
+
         public void SaveScrollPositionOnMovingIntoFolder()
         {
             ScrollPositionBeforeMovingIntoFolder = ((LinearLayoutManager)recycleLayoutManager).FindFirstVisibleItemPosition();
@@ -767,6 +819,18 @@ namespace Seeker
         public static ActionMode TransfersActionMode = null;
         public static List<int> BatchSelectedItems = new List<int>();
 
+        public static int GetGlobalIndexFromAdapterPosition(int adapterPosition)
+        {
+            var adapter = StaticHacks.TransfersFrag?.recyclerTransferAdapter;
+            if (adapter == null)
+            {
+                return adapterPosition;
+            }
+
+            int globalIndex = adapter.GetGlobalIndexForAdapterPosition(adapterPosition);
+            return globalIndex == -1 ? adapterPosition : globalIndex;
+        }
+
         public void SetRecyclerAdapter(bool restoreState = false)
         {
             lock (TransferItemManagerWrapped.GetUICurrentList())
@@ -788,16 +852,26 @@ namespace Seeker
                 }
 
 
-                if (GroupByFolder && !CurrentlyInFolder())
+                object currentList = TransferItemManagerWrapped.GetUICurrentList();
+                System.Collections.IList listForAdapter = currentList as System.Collections.IList ?? new List<ITransferItem>();
+                bool showFolders = GroupByFolder && !CurrentlyInFolder();
+                List<int> filteredPositions = BuildFilteredPositions(showFolders, currentList);
+                if (filteredPositions != null && filteredPositions.Count == listForAdapter.Count)
                 {
-                    recyclerTransferAdapter = new TransferAdapterRecyclerFolderItem(TransferItemManagerWrapped.GetUICurrentList() as List<FolderItem>);
+                    filteredPositions = null;
+                }
+
+                if (showFolders)
+                {
+                    recyclerTransferAdapter = new TransferAdapterRecyclerFolderItem(listForAdapter);
                 }
                 else
                 {
-                    recyclerTransferAdapter = new TransferAdapterRecyclerIndividualItem(TransferItemManagerWrapped.GetUICurrentList() as List<TransferItem>);
+                    recyclerTransferAdapter = new TransferAdapterRecyclerIndividualItem(listForAdapter);
                 }
                 recyclerTransferAdapter.TransfersFragment = this;
                 recyclerTransferAdapter.IsInBatchSelectMode = (TransfersActionMode != null);
+                recyclerTransferAdapter.UpdateFilterPositions(filteredPositions);
                 recyclerViewTransferItems.SetAdapter(recyclerTransferAdapter);
 
                 if (restoreState)
@@ -805,6 +879,136 @@ namespace Seeker
                     ((LinearLayoutManager)recycleLayoutManager).ScrollToPositionWithOffset(prevScrollPos, scrollOffset);
                 }
             }
+            SetNoTransfersMessage();
+        }
+
+        private List<int> BuildFilteredPositions(bool showFolders, object sourceList)
+        {
+            string filter = currentFilterQuery?.Trim();
+            if (string.IsNullOrEmpty(filter))
+            {
+                return null;
+            }
+
+            var comparison = StringComparison.OrdinalIgnoreCase;
+
+            if (showFolders && sourceList is List<FolderItem> folderList)
+            {
+                var matches = new List<int>();
+                for (int i = 0; i < folderList.Count; i++)
+                {
+                    if (FolderMatchesFilter(folderList[i], filter, comparison))
+                    {
+                        matches.Add(i);
+                    }
+                }
+                return matches;
+            }
+
+            if (sourceList is List<TransferItem> transferList)
+            {
+                var matches = new List<int>();
+                for (int i = 0; i < transferList.Count; i++)
+                {
+                    if (TransferItemMatchesFilter(transferList[i], filter, comparison))
+                    {
+                        matches.Add(i);
+                    }
+                }
+                return matches;
+            }
+
+            if (sourceList is IList genericList)
+            {
+                var matches = new List<int>();
+                for (int i = 0; i < genericList.Count; i++)
+                {
+                    if (genericList[i] is ITransferItem transferItem && MatchesFilter(transferItem, filter, comparison))
+                    {
+                        matches.Add(i);
+                    }
+                }
+                return matches;
+            }
+
+            return new List<int>();
+        }
+
+        private bool MatchesFilter(ITransferItem item, string filter, StringComparison comparison)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            if (item is TransferItem transferItem)
+            {
+                return TransferItemMatchesFilter(transferItem, filter, comparison);
+            }
+
+            if (item is FolderItem folderItem)
+            {
+                return FolderMatchesFilter(folderItem, filter, comparison);
+            }
+
+            var displayName = item.GetDisplayName();
+            return !string.IsNullOrEmpty(displayName) && displayName.IndexOf(filter, comparison) >= 0;
+        }
+
+        private bool TransferItemMatchesFilter(TransferItem item, string filter, StringComparison comparison)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(item.Filename) && item.Filename.IndexOf(filter, comparison) >= 0)
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(item.Username) && item.Username.IndexOf(filter, comparison) >= 0)
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(item.FolderName) && item.FolderName.IndexOf(filter, comparison) >= 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool FolderMatchesFilter(FolderItem folder, string filter, StringComparison comparison)
+        {
+            if (folder == null)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(folder.FolderName) && folder.FolderName.IndexOf(filter, comparison) >= 0)
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(folder.Username) && folder.Username.IndexOf(filter, comparison) >= 0)
+            {
+                return true;
+            }
+
+            if (folder.TransferItems != null)
+            {
+                foreach (var transferItem in folder.TransferItems)
+                {
+                    if (TransferItemMatchesFilter(transferItem, filter, comparison))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -922,20 +1126,16 @@ namespace Seeker
         }
 
 
-        //public override void OnDestroyView()
-        //{
-        //    try
-        //    {
-        //        SeekerState.SoulseekClient.TransferProgressUpdated -= SoulseekClient_TransferProgressUpdated;
-        //        SeekerState.SoulseekClient.TransferStateChanged -= SoulseekClient_TransferStateChanged;
-        //        MainActivity.TransferItemQueueUpdated -= TranferQueueStateChanged;
-        //    }
-        //    catch (System.Exception)
-        //    {
+        public override void OnDestroyView()
+        {
+            if (transfersFilterInput != null)
+            {
+                transfersFilterInput.TextChanged -= TransfersFilterInput_TextChanged;
+                transfersFilterInput = null;
+            }
 
-        //    }
-        //    base.OnDestroyView();
-        //}
+            base.OnDestroyView();
+        }
 
         //public override void OnDestroy()
         //{
@@ -1036,9 +1236,14 @@ namespace Seeker
             List<TransferItem> tis = new List<TransferItem>();
             foreach (int pos in BatchSelectedItems)
             {
+                int globalIndex = recyclerTransferAdapter?.GetGlobalIndexForAdapterPosition(pos) ?? pos;
+                if (globalIndex == -1)
+                {
+                    continue;
+                }
                 if (folderItems)
                 {
-                    var fi = TransferItemManagerDL.GetItemAtUserIndex(pos) as FolderItem;
+                    var fi = TransferItemManagerDL.GetItemAtUserIndex(globalIndex) as FolderItem;
                     foreach (TransferItem ti in fi.TransferItems)
                     {
                         if (selectFailed && ti.Failed)
@@ -1053,7 +1258,7 @@ namespace Seeker
                 }
                 else
                 {
-                    var ti = TransferItemManagerDL.GetItemAtUserIndex(pos) as TransferItem;
+                    var ti = TransferItemManagerDL.GetItemAtUserIndex(globalIndex) as TransferItem;
                     if (selectFailed && ti.Failed)
                     {
                         tis.Add(ti);
@@ -1183,7 +1388,7 @@ namespace Seeker
                             MainActivity.LogDebug($"updating {i}");
                             if (StaticHacks.TransfersFrag != null)
                             {
-                                StaticHacks.TransfersFrag.recyclerTransferAdapter?.NotifyItemChanged(i);
+                                StaticHacks.TransfersFrag.recyclerTransferAdapter?.NotifyItemChangedForGlobalIndex(i);
                             }
                         }
 
@@ -1299,7 +1504,7 @@ namespace Seeker
 
                 MainActivity.LogDebug("notifyItemChanged " + position);
 
-                recyclerTransferAdapter.NotifyItemChanged(position);
+                recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(position);
 
 
             });
@@ -1397,6 +1602,7 @@ namespace Seeker
                         //clear complete?
                         //info = (AdapterView.AdapterContextMenuInfo)item.MenuInfo;
                         MainActivity.LogInfoFirebase("Clear Complete item pressed");
+                        bool requiresRefresh = IsFilterActive;
                         lock (TransferItemManagerWrapped.GetUICurrentList()) //TODO: test
                         {
                             try
@@ -1412,13 +1618,19 @@ namespace Seeker
                             }
                             catch (ArgumentOutOfRangeException)
                             {
-                                //MainActivity.LogFirebase("case1: info.Position: " + position + " transferItems.Count is: " + transferItems.Count);
                                 Toast.MakeText(SeekerState.ActiveActivityRef, "Selected transfer does not exist anymore.. try again.", ToastLength.Short).Show();
                                 return base.OnContextItemSelected(item);
                             }
-                            recyclerTransferAdapter.NotifyItemRemoved(position);  //UI
-                            //refreshListView();
                         }
+                        if (requiresRefresh)
+                        {
+                            SetRecyclerAdapter(true);
+                        }
+                        else
+                        {
+                            recyclerTransferAdapter.NotifyItemRemoved(position);  //UI
+                        }
+                        //refreshListView();
                         break;
                     case 2: //cancel and clear (downloads) OR abort and clear (uploads)
                         //info = (AdapterView.AdapterContextMenuInfo)item.MenuInfo;
@@ -1441,6 +1653,7 @@ namespace Seeker
                             uptoken?.Cancel();
                             //CancellationTokens[ProduceCancellationTokenKey(tItem)]?.Cancel(); throws if does not exist.
                             CancellationTokens.Remove(ProduceCancellationTokenKey(tti), out _);
+                            bool requiresRefresh = IsFilterActive;
                             lock (TransferItemManagerWrapped.GetUICurrentList())
                             {
                                 if (InUploadsMode)
@@ -1451,6 +1664,13 @@ namespace Seeker
                                 {
                                     TransferItemManagerWrapped.RemoveAndCleanUpAtUserIndex(position); //this means basically, wait for the stream to be closed. no race conditions..
                                 }
+                            }
+                            if (requiresRefresh)
+                            {
+                                SetRecyclerAdapter(true);
+                            }
+                            else
+                            {
                                 recyclerTransferAdapter.NotifyItemRemoved(position);
                             }
                         }
@@ -1458,9 +1678,17 @@ namespace Seeker
                         {
                             TransferItemManagerWrapped.CancelFolder(fi, true);
                             TransferItemManagerWrapped.ClearAllFromFolderAndClean(fi);
+                            bool requiresRefresh = IsFilterActive;
                             lock (TransferItemManagerWrapped.GetUICurrentList())
                             {
                                 //TransferItemManagerDL.RemoveAtUserIndex(position); we already removed
+                            }
+                            if (requiresRefresh)
+                            {
+                                SetRecyclerAdapter(true);
+                            }
+                            else
+                            {
                                 recyclerTransferAdapter.NotifyItemRemoved(position);
                             }
                         }
@@ -1623,7 +1851,7 @@ namespace Seeker
                     case 101: //pause folder or abort uploads (uploads)
                         TransferItemManagerWrapped.CancelFolder(ti as FolderItem);
                         int index = TransferItemManagerWrapped.GetIndexForFolderItem(ti as FolderItem);
-                        recyclerTransferAdapter.NotifyItemChanged(index);
+                        recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(index);
                         break;
                     case 102: //retry failed downloads from folder
                         if (NotLoggedInShowMessageGaurd("retry folder"))
@@ -1685,7 +1913,7 @@ namespace Seeker
                         CancellationTokens.Remove(ProduceCancellationTokenKey(uploadToCancel), out _);
                         lock (TransferItemManagerWrapped.GetUICurrentList())
                         {
-                            recyclerTransferAdapter.NotifyItemChanged(position);
+                            recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(position);
                         }
                         break;
                     case 104: //ignore (unshare) user
@@ -1701,7 +1929,7 @@ namespace Seeker
                                 int posOfCancelled = TransferItemManagerWrapped.GetUserIndexForTransferItem(tiToCancel);
                                 if (posOfCancelled != -1)
                                 {
-                                    recyclerTransferAdapter.NotifyItemChanged(posOfCancelled);
+                                    recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(posOfCancelled);
                                 }
                             }
                         }
@@ -1758,17 +1986,23 @@ namespace Seeker
                 MainActivity.LogDebug("batch on, different screen item removed");
                 return;
             }
+            int adapterPositionBeingRemoved = StaticHacks.TransfersFrag?.recyclerTransferAdapter?.GetAdapterPositionForGlobalIndex(userPostionBeingRemoved) ?? -1;
+            if (adapterPositionBeingRemoved == -1)
+            {
+                MainActivity.LogDebug("batch on, item not visible in current filter");
+                return;
+            }
             MainActivity.LogDebug("batch on, updating: " + userPostionBeingRemoved);
             //adjust numbers
             int cnt = BatchSelectedItems.Count;
             for (int i = cnt - 1; i >= 0; i--)
             {
                 int position = BatchSelectedItems[i];
-                if (position < userPostionBeingRemoved)
+                if (position < adapterPositionBeingRemoved)
                 {
                     continue;
                 }
-                else if (position == userPostionBeingRemoved)
+                else if (position == adapterPositionBeingRemoved)
                 {
                     BatchSelectedItems.RemoveAt(i);
                 }
@@ -1873,9 +2107,16 @@ namespace Seeker
                         TransferItemManagerWrapped.ClearSelectedItemsAndClean();
                         var selected = BatchSelectedItems.ToArray();
                         BatchSelectedItems.Clear();
-                        foreach (int pos in selected)
+                        if (Frag != null && Frag.IsFilterActive)
                         {
-                            Adapter.NotifyItemRemoved(pos);
+                            Frag.SetRecyclerAdapter(true);
+                        }
+                        else
+                        {
+                            foreach (int pos in selected)
+                            {
+                                Adapter.NotifyItemRemoved(pos);
+                            }
                         }
                         //since all selected stuff is going away. its what Gmail action mode does.
                         TransfersActionMode.Finish(); //TransfersActionMode can be null!
@@ -1989,7 +2230,7 @@ namespace Seeker
                         {
                             return null;
                         }
-                        recyclerTransferAdapter.NotifyItemChanged(indexOfItem);
+                        recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(indexOfItem);
                     }
                 }
                 catch (System.Exception e)
@@ -2019,7 +2260,7 @@ namespace Seeker
 
                 }
                 MainActivity.LogDebug("UI thread: " + Looper.MainLooper.IsCurrentThread);
-                recyclerTransferAdapter.NotifyItemChanged(indexOfItem);
+                recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(indexOfItem);
             }
             catch (System.Exception)
             {
@@ -2174,7 +2415,7 @@ namespace Seeker
             {
 
             }
-            recyclerTransferAdapter.NotifyItemChanged(indexOfItem);
+            recyclerTransferAdapter.NotifyItemChangedForGlobalIndex(indexOfItem);
 
         }
 
@@ -2233,7 +2474,8 @@ namespace Seeker
 
             public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
             {
-                (holder as TransferViewHolder).getTransferItemView().setItem(localDataSet[position] as TransferItem, this.IsInBatchSelectMode);
+                var item = GetItemForAdapterPosition(position) as TransferItem;
+                (holder as TransferViewHolder).getTransferItemView().setItem(item, this.IsInBatchSelectMode);
                 //(holder as TransferViewHolder).getTransferItemView().LongClick += TransferAdapterRecyclerVersion_LongClick; //I dont think we should be adding this here.  you get 3 after a short time...
             }
 
@@ -2285,7 +2527,8 @@ namespace Seeker
 
             public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
             {
-                (holder as TransferViewHolder).getTransferItemView().setItem(localDataSet[position] as FolderItem, this.IsInBatchSelectMode);
+                var item = GetItemForAdapterPosition(position) as FolderItem;
+                (holder as TransferViewHolder).getTransferItemView().setItem(item, this.IsInBatchSelectMode);
                 //(holder as TransferViewHolder).getTransferItemView().LongClick += TransferAdapterRecyclerVersion_LongClick; //I dont think we should be adding this here.  you get 3 after a short time...
             }
 
@@ -2381,7 +2624,8 @@ namespace Seeker
         public abstract class TransferAdapterRecyclerVersion : RecyclerView.Adapter //<TransferAdapterRecyclerVersion.TransferViewHolder>
         {
             protected System.Collections.IList localDataSet;
-            public override int ItemCount => localDataSet.Count;
+            private List<int> filteredPositions = null;
+            public override int ItemCount => filteredPositions?.Count ?? localDataSet.Count;
             protected ITransferItem selectedItem = null;
             public bool IsInBatchSelectMode;
 
@@ -2429,6 +2673,98 @@ namespace Seeker
                 localDataSet = tranfersList;
                 showSpeed = SeekerState.TransferViewShowSpeed;
                 showSizes = SeekerState.TransferViewShowSizes;
+            }
+
+            public void UpdateFilterPositions(List<int> positions)
+            {
+                if (positions != null && positions.Count == localDataSet.Count)
+                {
+                    filteredPositions = null;
+                }
+                else
+                {
+                    filteredPositions = positions != null ? new List<int>(positions) : null;
+                }
+            }
+
+            protected int GetActualIndex(int adapterPosition)
+            {
+                if (filteredPositions == null)
+                {
+                    if (adapterPosition >= 0 && adapterPosition < localDataSet.Count)
+                    {
+                        return adapterPosition;
+                    }
+                    return -1;
+                }
+
+                if (adapterPosition >= 0 && adapterPosition < filteredPositions.Count)
+                {
+                    return filteredPositions[adapterPosition];
+                }
+                return -1;
+            }
+
+            protected object GetItemForAdapterPosition(int adapterPosition)
+            {
+                int actualIndex = GetActualIndex(adapterPosition);
+                if (actualIndex == -1 || actualIndex >= localDataSet.Count)
+                {
+                    return null;
+                }
+                return localDataSet[actualIndex];
+            }
+
+            public int GetGlobalIndexForAdapterPosition(int adapterPosition)
+            {
+                return GetActualIndex(adapterPosition);
+            }
+
+            public int GetAdapterPositionForGlobalIndex(int globalIndex)
+            {
+                if (filteredPositions == null)
+                {
+                    if (globalIndex >= 0 && globalIndex < localDataSet.Count)
+                    {
+                        return globalIndex;
+                    }
+                    return -1;
+                }
+
+                return filteredPositions.IndexOf(globalIndex);
+            }
+
+            public void NotifyItemChangedForGlobalIndex(int globalIndex)
+            {
+                int adapterIndex = GetAdapterPositionForGlobalIndex(globalIndex);
+                if (adapterIndex != -1)
+                {
+                    NotifyItemChanged(adapterIndex);
+                }
+            }
+
+            public void NotifyItemChangedForItem(ITransferItem item)
+            {
+                if (item == null)
+                {
+                    return;
+                }
+
+                int adapterIndex;
+                if (filteredPositions == null)
+                {
+                    adapterIndex = localDataSet.IndexOf(item);
+                }
+                else
+                {
+                    int globalIndex = localDataSet.IndexOf(item);
+                    adapterIndex = globalIndex >= 0 ? filteredPositions.IndexOf(globalIndex) : -1;
+                }
+
+                if (adapterIndex != -1)
+                {
+                    NotifyItemChanged(adapterIndex);
+                }
             }
 
         }

--- a/Seeker/Views/EnhancedRecyclerView.cs
+++ b/Seeker/Views/EnhancedRecyclerView.cs
@@ -1,0 +1,196 @@
+using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using AndroidX.RecyclerView.Widget;
+using System;
+
+namespace Seeker.Views
+{
+    public class EnhancedRecyclerView : RecyclerView
+    {
+        private bool fastScrollTouchActive = false;
+        private int fastScrollTouchAreaPx;
+
+        public EnhancedRecyclerView(Context context) : base(context)
+        {
+            Initialize(context);
+        }
+
+        public EnhancedRecyclerView(Context context, IAttributeSet attrs) : base(context, attrs)
+        {
+            Initialize(context);
+        }
+
+        public EnhancedRecyclerView(Context context, IAttributeSet attrs, int defStyle) : base(context, attrs, defStyle)
+        {
+            Initialize(context);
+        }
+
+        protected EnhancedRecyclerView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+            Initialize(Context);
+        }
+
+        private void Initialize(Context context)
+        {
+            var metrics = context?.Resources?.DisplayMetrics ?? Resources?.DisplayMetrics;
+            fastScrollTouchAreaPx = metrics != null ? (int)TypedValue.ApplyDimension(ComplexUnitType.Dip, 32f, metrics) : 48;
+            Focusable = true;
+            FocusableInTouchMode = true;
+        }
+
+        public override bool OnInterceptTouchEvent(MotionEvent e)
+        {
+            if (HandleFastScrollTouch(e))
+            {
+                return true;
+            }
+            return base.OnInterceptTouchEvent(e);
+        }
+
+        public override bool OnTouchEvent(MotionEvent e)
+        {
+            if (HandleFastScrollTouch(e))
+            {
+                return true;
+            }
+            return base.OnTouchEvent(e);
+        }
+
+        private bool HandleFastScrollTouch(MotionEvent e)
+        {
+            if (LayoutManager == null || Adapter == null)
+            {
+                fastScrollTouchActive = false;
+                return false;
+            }
+
+            switch (e.ActionMasked)
+            {
+                case MotionEventActions.Down:
+                case MotionEventActions.ButtonPress:
+                    if (IsInFastScrollRegion(e.GetX()))
+                    {
+                        fastScrollTouchActive = true;
+                        Parent?.RequestDisallowInterceptTouchEvent(true);
+                        ScrollToFastScrollPosition(e.GetY());
+                        return true;
+                    }
+                    break;
+                case MotionEventActions.Move:
+                    if (fastScrollTouchActive)
+                    {
+                        ScrollToFastScrollPosition(e.GetY());
+                        return true;
+                    }
+                    break;
+                case MotionEventActions.Up:
+                case MotionEventActions.Cancel:
+                case MotionEventActions.ButtonRelease:
+                    if (fastScrollTouchActive)
+                    {
+                        ScrollToFastScrollPosition(e.GetY());
+                        fastScrollTouchActive = false;
+                        return true;
+                    }
+                    break;
+            }
+
+            return fastScrollTouchActive;
+        }
+
+        private bool IsInFastScrollRegion(float x)
+        {
+            return x >= Width - fastScrollTouchAreaPx;
+        }
+
+        private void ScrollToFastScrollPosition(float y)
+        {
+            var adapter = Adapter;
+            if (adapter == null)
+            {
+                return;
+            }
+
+            int itemCount = adapter.ItemCount;
+            if (itemCount == 0)
+            {
+                return;
+            }
+
+            int height = Height - PaddingTop - PaddingBottom;
+            if (height <= 0)
+            {
+                return;
+            }
+
+            float clampedY = Math.Max(0f, Math.Min(y - PaddingTop, height));
+            float proportion = clampedY / height;
+            int targetPosition = (int)Math.Round(proportion * (itemCount - 1));
+            targetPosition = Math.Max(0, Math.Min(itemCount - 1, targetPosition));
+
+            if (LayoutManager is LinearLayoutManager linear)
+            {
+                linear.ScrollToPositionWithOffset(targetPosition, 0);
+            }
+            else
+            {
+                ScrollToPosition(targetPosition);
+            }
+        }
+
+        public override bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
+        {
+            if (HandleKeyboardScroll(keyCode))
+            {
+                return true;
+            }
+            return base.OnKeyDown(keyCode, e);
+        }
+
+        private bool HandleKeyboardScroll(Keycode keyCode)
+        {
+            if (!(LayoutManager is LinearLayoutManager linear) || Adapter == null)
+            {
+                return false;
+            }
+
+            switch (keyCode)
+            {
+                case Keycode.PageDown:
+                    return ScrollByPage(linear, true);
+                case Keycode.PageUp:
+                    return ScrollByPage(linear, false);
+                case Keycode.MoveEnd:
+                    ScrollToPosition(Adapter.ItemCount - 1);
+                    return true;
+                case Keycode.MoveHome:
+                    ScrollToPosition(0);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private bool ScrollByPage(LinearLayoutManager layoutManager, bool forward)
+        {
+            int visibleCount = layoutManager.ChildCount;
+            if (visibleCount <= 0)
+            {
+                return false;
+            }
+
+            int firstVisible = layoutManager.FindFirstVisibleItemPosition();
+            if (firstVisible == RecyclerView.NoPosition)
+            {
+                return false;
+            }
+
+            int target = forward ? firstVisible + visibleCount : firstVisible - visibleCount;
+            target = Math.Max(0, Math.Min(Adapter.ItemCount - 1, target));
+            layoutManager.ScrollToPositionWithOffset(target, 0);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the transfers list with an enhanced recycler view that supports fast-scroll tapping and keyboard navigation
- add a real-time filter panel on the Transfers screen and hide the legacy scrollbar
- adjust selection and manager logic to respect filtered indices and show a friendly empty state message

## Testing
- not run (Android build environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68f2259153dc832db22f5a36738d9bbb