### PR TITLE
Fix missing tItem declaration in TransfersFragment

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -1555,6 +1555,8 @@ namespace Seeker
                     return base.OnContextItemSelected(item);
                 }
 
+                ITransferItem tItem = null;
+
                 switch (item.ItemId)
                 {
                     case 0: //single transfer only
@@ -1638,7 +1640,6 @@ namespace Seeker
                     {
                         //info = (AdapterView.AdapterContextMenuInfo)item.MenuInfo;
                         MainActivity.LogInfoFirebase("Cancel and Clear item pressed");
-                        ITransferItem tItem = null;
                         try
                         {
                             tItem = TransferItemManagerWrapped.GetItemAtUserIndex(position);


### PR DESCRIPTION
## Summary
- declare the shared `tItem` variable before the context menu switch
- remove the redundant inner declaration that limited scope to case 2

## Testing
- `dotnet build Seeker/Seeker.csproj` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f26cbba268832d840dcf682bcc40c0