### PR TITLE
Disable default RecyclerView scrollbars in transfers layout

### DIFF
--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -10,7 +10,7 @@
             android:layout_below="@id/header1"
             android:minWidth="25px"
             android:minHeight="25px"
-            android:scrollbars="vertical"
+            android:scrollbars="none"
             app:fastScrollEnabled="true"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"


### PR DESCRIPTION
## Summary
- disable the default vertical scrollbar on the transfers list while keeping the custom fast scroll drawables in place

## Testing
- `dotnet build Seeker.sln` *(fails: dotnet not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f27bae67c4832db597439d8a7497c1