### PR TITLE
Add debounced transfer filtering UI

### DIFF
--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -6,8 +6,42 @@
         android:layout_height="match_parent"
         tools:context="android.PageFragment"
         android:id="@+id/relativeLayout1">
-    <androidx.recyclerview.widget.RecyclerView
+    <LinearLayout
+            android:id="@+id/transferFilterContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_below="@id/header1"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
+        <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/filter_transfers">
+            <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/transferFilterEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:singleLine="true"/>
+        </com.google.android.material.textfield.TextInputLayout>
+        <ImageButton
+                android:id="@+id/transferFilterClearButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/clear_filter"
+                android:padding="8dp"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                android:tint="?attr/colorControlNormal"
+                android:visibility="gone"/>
+    </LinearLayout>
+    <androidx.recyclerview.widget.RecyclerView
+            android:layout_below="@id/transferFilterContainer"
             android:minWidth="25px"
             android:minHeight="25px"
             android:scrollbars="none"

--- a/Seeker/Resources/values-ru/strings.xml
+++ b/Seeker/Resources/values-ru/strings.xml
@@ -87,6 +87,8 @@
     <string name="chatroom_enter_message">Введите сообщение</string>
     <string name="send_message">Отправить</string>
     <string name="filter_chatrooms_here">Фильтр</string>
+    <string name="filter_transfers">Фильтр передач</string>
+    <string name="clear_filter">Очистить фильтр</string>
     <string name="enter_listening_port">Введите порт для прослушивания</string>
     <string name="create_chatroom_name">Имя комнаты</string>
     <string name="create_chatroom_private">Сделать приватной</string>

--- a/Seeker/Resources/values/strings.xml
+++ b/Seeker/Resources/values/strings.xml
@@ -99,6 +99,8 @@ Directory Count: {5}"</string>
   <string name="chatroom_enter_message">Enter Message</string>
   <string name="send_message">Send</string>
   <string name="filter_chatrooms_here">Filter here</string>
+  <string name="filter_transfers">Filter transfers</string>
+  <string name="clear_filter">Clear filter</string>
 
   <string name="enter_listening_port">Enter Port to Listen On</string>
 

--- a/Seeker/Transfers/TransferItemManager.cs
+++ b/Seeker/Transfers/TransferItemManager.cs
@@ -243,6 +243,7 @@ namespace Seeker
         /// <returns></returns>
         public object RemoveAtUserIndex(int indexOfItem)
         {
+            indexOfItem = TransfersFragment.MapFilteredIndexToSource(indexOfItem);
             if (TransfersFragment.GroupByFolder)
             {
                 if (TransfersFragment.GetCurrentlySelectedFolder() != null)
@@ -278,6 +279,7 @@ namespace Seeker
 
         public ITransferItem GetItemAtUserIndex(int indexOfItem)
         {
+            indexOfItem = TransfersFragment.MapFilteredIndexToSource(indexOfItem);
             if (TransfersFragment.GroupByFolder)
             {
                 if (TransfersFragment.GetCurrentlySelectedFolder() != null)
@@ -302,11 +304,12 @@ namespace Seeker
         /// <returns></returns>
         public int GetUserIndexForTransferItem(TransferItem ti)
         {
+            int actualIndex = -1;
             if (TransfersFragment.GroupByFolder)
             {
                 if (TransfersFragment.GetCurrentlySelectedFolder() != null)
                 {
-                    return TransfersFragment.GetCurrentlySelectedFolder().TransferItems.IndexOf(ti);
+                    actualIndex = TransfersFragment.GetCurrentlySelectedFolder().TransferItems.IndexOf(ti);
                 }
                 else
                 {
@@ -315,20 +318,30 @@ namespace Seeker
                     {
                         foldername = Common.Helpers.GetFolderNameFromFile(ti.FullFilename);
                     }
-                    return AllFolderItems.FindIndex((FolderItem fi) => { return fi.FolderName == foldername && fi.Username == ti.Username; });
+                    actualIndex = AllFolderItems.FindIndex((FolderItem fi) => { return fi.FolderName == foldername && fi.Username == ti.Username; });
                 }
             }
             else
             {
-                return AllTransferItems.IndexOf(ti);
+                actualIndex = AllTransferItems.IndexOf(ti);
             }
+            if (actualIndex == -1)
+            {
+                return -1;
+            }
+            return TransfersFragment.MapSourceIndexToFiltered(actualIndex);
         }
 
         public int GetIndexForFolderItem(FolderItem ti)
         {
             lock (AllFolderItems)
             {
-                return AllFolderItems.IndexOf(ti);
+                int actualIndex = AllFolderItems.IndexOf(ti);
+                if (actualIndex == -1)
+                {
+                    return -1;
+                }
+                return TransfersFragment.MapSourceIndexToFiltered(actualIndex);
             }
         }
 
@@ -355,11 +368,12 @@ namespace Seeker
         /// <returns></returns>
         public int GetUserIndexForTransferItem(string fullfilename)
         {
+            int actualIndex = -1;
             if (TransfersFragment.GroupByFolder)
             {
                 if (TransfersFragment.GetCurrentlySelectedFolder() != null)
                 {
-                    return TransfersFragment.GetCurrentlySelectedFolder().TransferItems.FindIndex((ti) => ti.FullFilename == fullfilename);
+                    actualIndex = TransfersFragment.GetCurrentlySelectedFolder().TransferItems.FindIndex((ti) => ti.FullFilename == fullfilename);
                 }
                 else
                 {
@@ -368,18 +382,27 @@ namespace Seeker
                     {
                         ti = AllTransferItems.Find((ti) => ti.FullFilename == fullfilename);
                     }
+                    if (ti == null)
+                    {
+                        return -1;
+                    }
                     string foldername = ti.FolderName;
                     if (foldername == null)
                     {
                         foldername = Common.Helpers.GetFolderNameFromFile(ti.FullFilename);
                     }
-                    return AllFolderItems.FindIndex((FolderItem fi) => { return fi.FolderName == foldername && fi.Username == ti.Username; });
+                    actualIndex = AllFolderItems.FindIndex((FolderItem fi) => { return fi.FolderName == foldername && fi.Username == ti.Username; });
                 }
             }
             else
             {
-                return AllTransferItems.FindIndex((ti) => ti.FullFilename == fullfilename);
+                actualIndex = AllTransferItems.FindIndex((ti) => ti.FullFilename == fullfilename);
             }
+            if (actualIndex == -1)
+            {
+                return -1;
+            }
+            return TransfersFragment.MapSourceIndexToFiltered(actualIndex);
         }
 
 


### PR DESCRIPTION
## Summary
- add a filter bar with text input and clear button above the transfers list
- debounce filter edits and update adapters with filtered copies across transfer/group modes
- update transfer index helpers to respect filtered ordering and add localized filter strings

## Testing
- dotnet build Seeker.sln *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f27f7f19d0832db5295bc1212dc98b