### PR TITLE
Remove unsupported Keycode.End case in TransfersFragment

### DIFF
--- a/Seeker/Transfers/TransfersFragment.cs
+++ b/Seeker/Transfers/TransfersFragment.cs
@@ -890,7 +890,6 @@ namespace Seeker
                     e.Handled = true;
                     break;
                 case Keycode.MoveEnd:
-                case Keycode.End:
                     targetPosition = itemCount - 1;
                     linearLayoutManager.ScrollToPositionWithOffset(targetPosition, 0);
                     e.Handled = true;


### PR DESCRIPTION
## Summary
- remove usage of the nonexistent `Keycode.End` constant when handling key events in `TransfersFragment`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2a85f4728832dad4aad9c502ea167