### PR TITLE
Adjust fast scroll thumb drawables

### DIFF
--- a/Seeker/Resources/drawable/fastscroll_thumb_horizontal.xml
+++ b/Seeker/Resources/drawable/fastscroll_thumb_horizontal.xml
@@ -2,8 +2,8 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <!-- Wider thumb for easier touch interaction -->
-            <size android:width="24dp" />
+            <!-- Taller thumb for horizontal fast scroll interactions -->
+            <size android:height="24dp" />
             <solid android:color="@color/fastscroll_thumb_color" />
             <corners android:radius="12dp" />
         </shape>

--- a/Seeker/Resources/layout/searches.xml
+++ b/Seeker/Resources/layout/searches.xml
@@ -37,7 +37,7 @@
                 app:fastScrollEnabled="true"
                 app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
                 app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
-                app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
+                app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb_horizontal"
                 app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
                 android:paddingBottom="80dp"
                 android:clipToPadding="false"

--- a/Seeker/Resources/layout/transfers.xml
+++ b/Seeker/Resources/layout/transfers.xml
@@ -48,7 +48,7 @@
             app:fastScrollEnabled="true"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_track"
-            app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
+            app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb_horizontal"
             app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_track"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
## Summary
- drop the fixed height from the vertical fast scroll thumb so drag calculations use the list height
- add a horizontal fast scroll thumb drawable that preserves the thicker touch target
- point horizontal fast scroll attributes at the new drawable in Transfers and Searches layouts

## Testing
- dotnet build Seeker/Seeker.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2adb1b520832db3ec429aa7ecbed6