### PR TITLE
Set fast scroll minimum range to zero

### DIFF
--- a/Seeker/Resources/values/dimens.xml
+++ b/Seeker/Resources/values/dimens.xml
@@ -10,7 +10,7 @@
         <dimen name="browse_no_details_top_bottom">4dp</dimen>
         <dimen name="browse_details_top">2dp</dimen>
         <dimen name="browse_details_bottom">1dp</dimen>
-    <dimen name="fastscroll_minimum_range">48dp</dimen>
+    <dimen name="fastscroll_minimum_range">0dp</dimen>
 
 
 </resources>


### PR DESCRIPTION
## Summary
- set fast scroll minimum range dimension to 0dp so the default library behavior is used

## Testing
- ❌ `dotnet build Seeker/Seeker.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68f2b9b6c2fc832d945df934cccc4249